### PR TITLE
Revert sdcardf2fs

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -129,9 +129,6 @@ persist.data.df.mux_count=8
 persist.data.df.iwlan_mux=9
 persist.data.df.dev_name=rmnet_usb0
 
-# Storage
-ro.sdcardfs.enable=true
-
 # Timeservice
 persist.timed.enable=true
 


### PR DESCRIPTION
sdcardf2fs makes the gallery crashing, makes it unable to take photos and disables file transfer. It should be removed temporarily.
